### PR TITLE
scie-pants v0.2.1

### DIFF
--- a/Casks/pants.rb
+++ b/Casks/pants.rb
@@ -13,13 +13,13 @@ cask "pants" do
     end
   end
 
-  version "0.2.0"
+  version "0.2.1"
   if OS.mac?
-    sha256 arm: "03feb5fcc36599df5071ea1b27c044935865c54aa3b1e8452f2baed65861416e",
-           intel: "62d1a27cd0c5c9999f5148598820edcd19571b461605131faa7e8a39b8a0779e"
+    sha256 arm: "79ba5efeb606b1d3dc13d810003a7c99d418e6e977ec65860ba6ad131f747928",
+           intel: "c5bb6b99319a374b1e97dba17558e981c6e050b77823ad57ec0211a0efc366ce"
   else
-    sha256 arm: "b581d6cd75ea803ad7419275044320fadc34257e55a066270abedbd630625c79",
-           intel: "ec8aa3224eb3313023a9dd14cafb2f13f14ce3af3dc6d42ee44be9543b3c192b"
+    sha256 arm: "ab062b11b18e96e1877c69946a807eaa2ac2ca8e96902a377e055bfc3684a77b",
+           intel: "f70a78a2470f909d42f6b306a7e96e270d1eaabeb19778007c20e2e13ba5c696"
   end
   url "https://github.com/pantsbuild/scie-pants/releases/download/v#{version}/scie-pants-#{Utils.os}-#{Utils.arch}",
       verified: "https://github.com/pantsbuild/"


### PR DESCRIPTION
https://github.com/pantsbuild/scie-pants/releases/tag/v0.2.1

@jsirois I experienced that when I upgrade `scie-pants`, it uses a new cache directory for bootstrapping pants. Is that correct?

Do I as an end-user need to manually clean up old cache entries under `~/Library/Caches/nce/` over time?