### PR TITLE
Add Linuxbrew support

### DIFF
--- a/.github/workflows/linuxbrew-install.yml
+++ b/.github/workflows/linuxbrew-install.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Install pants
         run: brew install --cask --verbose "$TAP/pants"
 
+      - name: Check pants cask
+        run: |
+          brew style --cask "$TAP/pants"
+          brew audit --cask "$TAP/pants"
+
       - name: Verify pants
         run: |
           command -v pants

--- a/.github/workflows/linuxbrew-install.yml
+++ b/.github/workflows/linuxbrew-install.yml
@@ -39,5 +39,5 @@ jobs:
       - name: Verify pants
         run: |
           command -v pants
-          pants --version
+          SCIE_BOOT=update pants --help
           brew list --cask pants

--- a/.github/workflows/linuxbrew-install.yml
+++ b/.github/workflows/linuxbrew-install.yml
@@ -1,0 +1,43 @@
+name: Linuxbrew install
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: Install pants on Linuxbrew
+    runs-on: ubuntu-latest
+    container: ghcr.io/homebrew/brew:main
+    timeout-minutes: 20
+    env:
+      TAP: ${{ github.repository_owner }}/tap
+
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          stable: true
+
+      - name: Show Homebrew configuration
+        run: brew config
+
+      - name: Install pants
+        run: brew install --cask --verbose "$TAP/pants"
+
+      - name: Verify pants
+        run: |
+          command -v pants
+          pants --version
+          brew list --cask pants

--- a/Casks/pants.rb
+++ b/Casks/pants.rb
@@ -1,29 +1,41 @@
 cask "pants" do
-  version "0.13.2"
-  sha256 "a6f3231413ca1f793caffa621171a4b1a0158e7488cd0b5bb3e742cb99cc72a8"
+  arch arm: "aarch64", intel: "x86_64"
+  os macos: "macos-aarch64", linux: "linux-#{arch}"
 
-  url "https://github.com/pantsbuild/scie-pants/releases/download/v#{version}/scie-pants-macos-aarch64",
+  artifact = "scie-pants-#{os}"
+
+  version "0.13.2"
+
+  on_macos do
+    sha256 "a6f3231413ca1f793caffa621171a4b1a0158e7488cd0b5bb3e742cb99cc72a8"
+
+    depends_on arch: :arm64
+
+    postflight do
+      Quarantine.release!(download_path: caskroom_path.join(version, artifact)) if Quarantine.available?
+    end
+  end
+
+  on_linux do
+    sha256 x86_64_linux: "74a1e53bc50d6ef6ce1bc67bd9f7b48e549505e0a2453ad4d5ccbc72b0bea874",
+           arm64_linux:  "b40b60e50e9cb69e13029e100be995fbfdb3b3799ef1ccff60a81177f78e6b82"
+
+    depends_on arch: [:arm64, :x86_64]
+  end
+
+  url "https://github.com/pantsbuild/scie-pants/releases/download/v#{version}/#{artifact}",
       verified: "github.com/pantsbuild/"
   name "Pants"
   desc "Fast, scalable, user-friendly build system for codebases of all sizes"
   homepage "https://pantsbuild.org/"
 
-  depends_on arch: :arm64
-
-  binary "scie-pants-macos-aarch64", target: "pants"
+  binary artifact, target: "pants"
 
   preflight do
     target = config.binarydir / "pants"
     if target.exist? && !target.symlink?
       opoo "replacing self-updated #{target}"
       target.delete
-    end
-  end
-
-  postflight do
-    if Quarantine.available?
-      Quarantine.release!(download_path: caskroom_path.join(version,
-                                                            "scie-pants-macos-aarch64"))
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds Linuxbrew support to the `pants` cask while preserving the existing macOS arm64 behavior.

## Validation

- `brew style Casks/pants.rb`
- `brew audit --cask pants`
- Github workflow which runs the install ([sample](https://github.com/HeroCC/homebrew-tap/actions/runs/27022866245/job/79755147271) run)